### PR TITLE
feat(parser)!: implement (customisable) parsers for command parameters' container types

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,37 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      - id: check-case-conflict
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+        args: [--fix=lf]
+      - id: trailing-whitespace
+        args: [--markdown-linebreak-ext=md]
+
+  - repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.9.0
+    hooks:
+      - id: python-check-blanket-noqa
+      - id: python-use-type-annotations
+
+  - repo: https://github.com/python-poetry/poetry
+    rev: '1.2.2'
+    hooks:
+      - id: poetry-check
+
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+
+  - repo: https://github.com/psf/black
+    rev: 22.10.0
+    hooks:
+      - id: black
+        language_version: python3
+
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.150
+    hooks:
+      - id: ruff

--- a/examples/parser.py
+++ b/examples/parser.py
@@ -1,0 +1,137 @@
+import asyncio
+import typing
+
+import velum
+import sail
+
+
+# Sail implements a bunch of parsers to convert your bot's users' string inputs
+# to all kinds of types. In most cases, this should be enough to work with to
+# make some very complex commands. However, it is possible to extend Sail's
+# functionality with your own parsers, just in case your needs are not quite
+# covered. We'll go over some examples here.
+
+client = velum.GatewayClient()
+manager = sail.CommandManager.with_prefix("!")
+manager.bind_to_app(client)
+
+
+# First, we'll make a simple float parser with some extra functionality.
+# Existing parser implementations can be found under `sail.impl.argument_parser`,
+# and prototypes to which your parsers should adhere can be found under
+# `sail.traits.argument_parser_trait`.
+
+# To create a new parser from scratch, we import the `ArgumentParser` trait,
+# and inherit from it. This way we can make sure that we implement everything
+# Sail needs from an argument parser. Note that this inheritance is not strictly
+# required, because it's ultimately just a prototype.
+
+# To support default values for parsing, we use a special sentinel type `EMPTY`.
+# This is used to differentiate between using `None` as default, and not having
+# a default at all. `EMPTY` and co. can be found under `sail.internal.empty`
+
+# We now import the bits required to make our custom parser.
+
+import math
+
+from sail.traits import argument_parser_trait
+from sail.internal import empty
+
+
+class FloatParser(argument_parser_trait.ArgumentParser[float]):
+
+    @property
+    def __type__(self) -> typing.Type[float]:
+        return float
+
+    def parse(self, argument: str, default: float | empty.Empty = empty.EMPTY) -> float:
+        # First, check for a couple special constants `float(str)` doesn't
+        # innately handle...
+        if argument == "pi":
+            return math.pi
+
+        if argument == "e":
+            return math.e
+
+        if argument == "tau":
+            return math.tau
+
+        # Not a special constant, try just casting to float...
+        try:
+            return float(argument)
+
+        except Exception:
+            # Failed to cast. Check if a default was provided...
+            if empty.is_nonempty(default):
+                return default
+
+            raise  # No default provided, just re-raise the exception.
+
+
+# Now we can use this custom parser as part of a command:
+
+@sail.param("number", parser=FloatParser())
+@manager.command()
+async def cool_floats(ctx: sail.Context, number: float):
+    await client.rest.send_message("Sail", f"You entered {number:.4f}!")
+
+
+# With this, if the command is invoked with e.g. `"!cool_floats pi"`, its
+# `number` argument will be parsed to 3.14159... as expected.
+
+# Something similar can be done with containers. Sail exposes a `ContainerParser`
+# trait, which is used in a similar fashion. The `parse` function of a container
+# parser will receive a sequence containing individual parsed elements. It is
+# then up to the container parser to finalize the sequence and cast it to the
+# desired container type.
+
+# Note that, in most situations, if you want to use a custom container type,
+# just using it as typehint is enough. As long as your custom type properly
+# implements the `typing.AbstractSet` or `typing.Sequence` traits, and
+# initialises with an iterable of values (e.g. `MyType([1,2,3])`), Sail should
+# be able to handle it without further trouble.
+
+# Now, for sake of illustration, we will make a custom container parser for
+# lists of strings, that filters out any strings that do not start with "@".
+
+class MentionContainerParser(argument_parser_trait.ContainerParser[typing.List[str]]):
+
+    @property
+    def __type__(self) -> typing.Type[typing.List[str]]:
+        return typing.List[str]
+
+    def parse(
+        self,
+        argument: typing.Sequence[object],
+        default: typing.List[str] | empty.Empty = empty.EMPTY
+    ) -> typing.List[str]:
+        parsed = [  # fmt: skip
+            arg
+            for arg in argument
+            if isinstance(arg, str)
+            and arg.startswith("@")
+        ]
+
+        if parsed:
+            return parsed
+
+        if empty.is_nonempty(default):
+            return default
+
+        raise TypeError("Got 0 valid mentions!")
+
+
+# And similarly, this can be passed to a command as follows:
+
+@sail.param("mentions", container_parser=MentionContainerParser())
+@manager.command()
+async def mention(ctx: sail.Context, mentions: typing.List[str]):
+    mention_str = "', '".join(mentions)
+    await client.rest.send_message("Sail", f"You mentioned '{mention_str}'!")
+
+
+# Which, when invoked with e.g. `"!mention @foo @bar bat @baz` would result in
+# the `mentions` param having value `["@foo", "@bar", "@baz"]`.
+
+
+asyncio.run(client.start())

--- a/examples/prefix.py
+++ b/examples/prefix.py
@@ -2,22 +2,21 @@ import asyncio
 import typing
 
 import velum
-
 import sail
 
-# To create commands, we first create a bot as per usual.
+# To create commands, we first create a client as per usual.
 # Next, we create a CommandManager. To set a prefix for the command manager,
 # simply use the classmethod `with_prefix(<prefix>)`.
 
-bot = velum.GatewayBot()
+client = velum.GatewayClient()
 manager = sail.CommandManager.with_prefix("!")
 
 
-# We then bind the command manager to the bot. This creates a listener for
+# We then bind the command manager to the client. This creates a listener for
 # `velum.MessageCreateEvent`s, that will automatically try to dispatch commands
 # if a message with correct prefix and command name was found.
 
-manager.bind_to_app(bot)
+manager.bind_to_app(client)
 
 
 # Now, we can add commands to the command manager.
@@ -34,7 +33,7 @@ manager.bind_to_app(bot)
 
 @manager.command(aliases=["cool-alias", "not_so_cool_alias"])
 async def my_command(ctx: sail.Context, x: typing.List[int], *, y: bool) -> None:
-    await bot.rest.send_message(
+    await client.rest.send_message(
         "sail",
         f"Got {len(x)} number(s): {x}. "
         f"Flag y was set to {y}. "
@@ -42,11 +41,11 @@ async def my_command(ctx: sail.Context, x: typing.List[int], *, y: bool) -> None
     )
 
 
-# Finally, we run the bot as per usual.
+# Finally, we run the client as per usual.
 # The command can now be invoked as e.g.
 # "!my_command 1 2 3 4 -y"
 # "!cool-alias 5 6"
 # "!not_so_cool_alias 7 8 9"
 # ...
 
-asyncio.run(bot.start())
+asyncio.run(client.start())

--- a/examples/turbofish.py
+++ b/examples/turbofish.py
@@ -3,7 +3,6 @@ import re
 import typing
 
 import velum
-
 import sail
 
 # ...But what if standard prefixes aren't cool enough?
@@ -27,11 +26,11 @@ def prepare(content: str) -> typing.Tuple[str | None, str | None, str | None]:
 # If all three return something other than None, the command manager will try
 # to invoke the command.
 
-# Next, we create a bot and command manager.
+# Next, we create a client and command manager.
 
-bot = velum.GatewayBot()
+client = velum.GatewayClient()
 manager = sail.CommandManager()
-manager.bind_to_app(bot)
+manager.bind_to_app(client)
 
 
 # We then bind our custom prepare callback to the manager:
@@ -44,7 +43,7 @@ manager.set_prepare_callback(prepare)
 
 @manager.command(aliases=["cool-alias", "not_so_cool_alias"])
 async def my_command(ctx: sail.Context, x: typing.List[int], *, y: bool) -> None:
-    await bot.rest.send_message(
+    await client.rest.send_message(
         "sail",
         f"Got {len(x)} number(s): {x}. "
         f"Flag y was set to {y}. "
@@ -59,6 +58,6 @@ async def my_command(ctx: sail.Context, x: typing.List[int], *, y: bool) -> None
 # ::<not_so_cool_alias> 1 2 3 4
 # ...
 
-# Finally, we run the bot as per usual.
+# Finally, we run the client as per usual.
 
-asyncio.run(bot.start())
+asyncio.run(client.start())

--- a/sail/__init__.py
+++ b/sail/__init__.py
@@ -5,6 +5,7 @@ from sail.errors import *
 from sail.impl.command import *
 from sail.impl.command_manager import *
 from sail.internal.typing_utils import Greedy as Greedy
+from sail.internal.typing_utils import JoinedStr as JoinedStr
 from sail.internal.undefined import UNDEFINED as UNDEFINED
 from sail.internal.undefined import UndefinedOr as UndefinedOr
 from sail.internal.undefined import UndefinedType as UndefinedType

--- a/sail/errors.py
+++ b/sail/errors.py
@@ -14,6 +14,7 @@ class SailError(errors.VelumError):
 @attr.define(auto_exc=True, repr=False, slots=False)
 class ConversionError(SailError):
 
-    argument: typing.Any
-    type: typing.Type[typing.Any]
-    exception: Exception
+    argument: typing.Any = attr.field()
+    type: typing.Type[typing.Any] = attr.field()
+    exception: Exception = attr.field()
+    converted: typing.Optional[typing.Any] = attr.field(default=None)

--- a/sail/errors.py
+++ b/sail/errors.py
@@ -11,9 +11,9 @@ class SailError(errors.VelumError):
     pass
 
 
-@attr.define(auto_exc=True, repr=False, init=False, slots=False)
+@attr.define(auto_exc=True, repr=False, slots=False)
 class ConversionError(SailError):
 
-    argument: str
+    argument: typing.Any
     type: typing.Type[typing.Any]
     exception: Exception

--- a/sail/impl/argument_parser.py
+++ b/sail/impl/argument_parser.py
@@ -154,8 +154,6 @@ class SequenceParser(_ContainerParser[SequenceT]):
 
     def __attrs_post_init__(self) -> None:
         # In case some non-instantiable generic was passed, default to list.
-        print("B", self.collection_type, isinstance(self.collection_type, abc.ABC))
-
         if isinstance(self.collection_type, abc.ABCMeta):
             self.collection_type = typing.cast(typing.Type[SequenceT], list)
 
@@ -165,8 +163,6 @@ class SetParser(_ContainerParser[SetT]):
 
     def __attrs_post_init__(self) -> None:
         # In case some non-instantiable generic was passed, default to set.
-        print("A", self.collection_type, isinstance(self.collection_type, abc.ABCMeta))
-
         if isinstance(self.collection_type, abc.ABCMeta):
             self.collection_type = typing.cast(typing.Type[SetT], set)
 

--- a/sail/impl/argument_parser.py
+++ b/sail/impl/argument_parser.py
@@ -200,3 +200,27 @@ class UnpackParser(argument_parser_trait.ContainerParser[typing.Any]):
             self.__type__,
             TypeError("Got 0 arguments for required parameter.")
         ) from None
+
+@attr.define()
+class JoinedStringParser(argument_parser_trait.ContainerParser[str]):
+
+    separator: str = attr.field(default=" ")
+
+    @property
+    def __type__(self) -> typing.Type[str]:
+        return str
+
+    def parse(
+        self,
+        argument: typing.Sequence[object],
+        default: str | empty.Empty = empty.EMPTY
+    ) -> str:
+        if not argument:
+            if empty.is_nonempty(default):
+                return default
+
+            raise TypeError("Got 0 arguments for required parameter.")
+    
+        assert all(isinstance(arg, str) for arg in argument)
+
+        return self.separator.join(typing.cast(typing.Sequence[str], argument))

--- a/sail/impl/command.py
+++ b/sail/impl/command.py
@@ -147,3 +147,35 @@ class Command(command_trait.Command[P, T]):
         ctx = Context(self, prefix, invoked_with, event, args, kwargs)
 
         await self.callback(ctx, *args, **kwargs)  # pyright: ignore[reportGeneralTypeIssues]
+
+
+def param(
+    name: str,
+    /,
+    *,
+    parser: undefined.UndefinedOr[
+        argument_parser_trait.ArgumentParser[T]
+    ] = undefined.UNDEFINED,
+    container_parser: undefined.UndefinedOr[
+        argument_parser_trait.ContainerParser[typing.Any]
+    ] = undefined.UNDEFINED,
+    default: undefined.UndefinedOr[T] = undefined.UNDEFINED,
+    short: undefined.UndefinedOr[str] = undefined.UNDEFINED,
+    greedy: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
+    flag: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
+) -> typing.Callable[[CommandT], CommandT]:
+
+    def wrapper(command: CommandT) -> CommandT:
+        command.update_param_typesafe(
+            name,
+            parser=parser,
+            container_parser=container_parser,
+            default=default,
+            short=short,
+            greedy=greedy,
+            flag=flag,
+        )
+
+        return command
+    
+    return wrapper

--- a/sail/impl/command.py
+++ b/sail/impl/command.py
@@ -16,6 +16,7 @@ from sail.traits import command_trait
 __all__: typing.Sequence[str] = (
     "Command",
     "Context",
+    "param",
 )
 
 
@@ -29,6 +30,7 @@ CommandCallback = typing.Callable[
     typing.Concatenate["Context", P],
     typing.Coroutine[typing.Any, typing.Any, T],
 ]
+CommandT = typing.TypeVar("CommandT", bound="Command[typing.Any, typing.Any]")
 
 
 @attr.define()
@@ -92,8 +94,10 @@ class Command(command_trait.Command[P, T]):
         parser: undefined.UndefinedOr[
             argument_parser_trait.ArgumentParser[T]
         ] = undefined.UNDEFINED,
+        container_parser: undefined.UndefinedOr[
+            argument_parser_trait.ContainerParser[typing.Any]
+        ] = undefined.UNDEFINED,
         default: undefined.UndefinedOr[T] = undefined.UNDEFINED,
-        container: undefined.UndefinedOr[AnyCollectionT] = undefined.UNDEFINED,
         short: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         greedy: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         flag: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
@@ -101,8 +105,8 @@ class Command(command_trait.Command[P, T]):
         self._signature_parser.update_param_typesafe(
             name,
             parser=parser,
+            container_parser=container_parser,
             default=default,
-            container=container,
             short=short,
             greedy=greedy,
             flag=flag,

--- a/sail/impl/param_info.py
+++ b/sail/impl/param_info.py
@@ -82,7 +82,7 @@ class ParamInfo(typing.Generic[T]):
 
     @property
     def has_container(self) -> bool:
-        return self.container_parser.__type__ is not types.NoneType
+        return self.container_parser.__type__ is not types.NoneType  # noqa: E721
 
     @classmethod
     def from_parameter(cls, parameter: inspect.Parameter) -> typing_extensions.Self:

--- a/sail/impl/param_info.py
+++ b/sail/impl/param_info.py
@@ -141,10 +141,9 @@ class ParamInfo(typing.Generic[T]):
             self.default = default
 
         if container_parser:
-            if (
-                self.container_parser.__type__ is not None
-                and not issubclass(container_parser.__type__, self.container_parser.__type__)
-            ):
+            _, container, _ = typing_utils.unpack_typehint(container_parser.__type__)
+
+            if container and not issubclass(container, self.container_parser.__type__):
                 raise TypeError(
                     "The override container parser's type must be a subtype of"
                     " the existing container parser's type."

--- a/sail/impl/param_info.py
+++ b/sail/impl/param_info.py
@@ -21,6 +21,7 @@ AnyContainer = typing.Container[typing.Any]
 def _determine_type_parser(
     type_: typing.Type[typing.Any],
     parameter_name: str,
+    annotated_params: typing.Sequence[typing.Any],
 ) -> argument_parser_trait.ArgumentParser[typing.Any]:
     if type_ is empty or type_ is typing.Any or issubclass(type_, str):
         return argument_parser.StringParser()
@@ -37,8 +38,11 @@ def _determine_type_parser(
 def _determine_container_parser(
     type_: typing.Optional[typing.Type[AnyContainer]],
     parameter_name: str,
+    annotated_params: typing.Sequence[typing.Any],
 ) -> argument_parser_trait.ContainerParser[typing.Any]:
-    if type_ is None:
+    if typing_utils.SpecialType.JOINEDSTR in annotated_params:
+        return argument_parser.JoinedStringParser()
+    elif type_ is None:
         return argument_parser.UnpackParser()
     elif issubclass(type_, typing.Sequence):
         return argument_parser.SequenceParser(type_)
@@ -103,8 +107,8 @@ class ParamInfo(typing.Generic[T]):
 
         return cls(
             parameter.name,
-            _determine_type_parser(inner, parameter.name),
-            _determine_container_parser(container, parameter.name),
+            _determine_type_parser(inner, parameter.name, annotated_params),
+            _determine_container_parser(container, parameter.name, annotated_params),
             default=parameter.default,
             greedy=greedy,
             flag=flag,

--- a/sail/impl/signature_parser.py
+++ b/sail/impl/signature_parser.py
@@ -30,10 +30,10 @@ class SignatureParser(signature_parser_trait.SignatureParser):
         parser: undefined.UndefinedOr[
             argument_parser_trait.ArgumentParser[T]
         ] = undefined.UNDEFINED,
-        default: undefined.UndefinedOr[T] = undefined.UNDEFINED,
         container_parser: undefined.UndefinedOr[
-            argument_parser_trait.ContainerParser[typing.Container[T]]
+            argument_parser_trait.ContainerParser[typing.Any]
         ] = undefined.UNDEFINED,
+        default: undefined.UndefinedOr[T] = undefined.UNDEFINED,
         short: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         greedy: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         flag: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
@@ -52,8 +52,8 @@ class SignatureParser(signature_parser_trait.SignatureParser):
 
         existing.override_typesafe(
             parser=parser,
-            default=default,
             container_parser=container_parser,
+            default=default,
             short=short,
             greedy=greedy,
             flag=flag,

--- a/sail/impl/signature_parser.py
+++ b/sail/impl/signature_parser.py
@@ -31,7 +31,9 @@ class SignatureParser(signature_parser_trait.SignatureParser):
             argument_parser_trait.ArgumentParser[T]
         ] = undefined.UNDEFINED,
         default: undefined.UndefinedOr[T] = undefined.UNDEFINED,
-        container: undefined.UndefinedOr[AnyCollectionT] = undefined.UNDEFINED,
+        container_parser: undefined.UndefinedOr[
+            argument_parser_trait.ContainerParser[typing.Container[T]]
+        ] = undefined.UNDEFINED,
         short: undefined.UndefinedOr[str] = undefined.UNDEFINED,
         greedy: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
         flag: undefined.UndefinedOr[bool] = undefined.UNDEFINED,
@@ -51,7 +53,7 @@ class SignatureParser(signature_parser_trait.SignatureParser):
         existing.override_typesafe(
             parser=parser,
             default=default,
-            container=container,
+            container_parser=container_parser,
             short=short,
             greedy=greedy,
             flag=flag,
@@ -68,14 +70,12 @@ class SignatureParser(signature_parser_trait.SignatureParser):
         next_param: param_info.ParamInfo[typing.Any],
         carry: typing.List[typing.Any],
     ) -> typing.Collection[typing.Any]:
-        assert param.container
-
         for arg in arg_iter:
             try:
                 carry.append(param.parser.parse(arg))
 
             except errors.ConversionError:
-                result: typing.Collection[typing.Any] = param.container.__call__(carry)
+                result: typing.Collection[typing.Any] = param.container_parser.parse(carry)
 
                 # Add the most recent param to the carry list for the
                 # next iteration.
@@ -84,7 +84,7 @@ class SignatureParser(signature_parser_trait.SignatureParser):
 
                 return result
 
-        result: typing.Collection[typing.Any] = param.container.__call__(carry)
+        result: typing.Collection[typing.Any] = param.container_parser.parse(carry)
         carry.clear()
 
         return result
@@ -96,30 +96,28 @@ class SignatureParser(signature_parser_trait.SignatureParser):
         next_param: param_info.ParamInfo[typing.Any],
         carry: typing.List[typing.Any],
     ) -> typing.Collection[typing.Any]:
-        assert param.container
-
         # We ensure the first arg always belongs to the param.
         # TODO: Do we really?
         carry.append(param.parser.parse(next(arg_iter)))
 
         for arg in arg_iter:
             try:
-                next_param.parser.parse(arg)
+                next_value = next_param.parser.parse(arg)
 
             except errors.ConversionError:
                 carry.append(param.parser.parse(arg))
 
             else:
-                result = param.container.__call__(carry)
+                result = param.container_parser.parse(carry)
 
                 # Add the most recent param to the carry list for the
                 # next iteration.
                 carry.clear()
-                carry.append(next_param.parser.parse(arg))
+                carry.append(next_value)
 
                 return result
 
-        result = param.container.__call__(carry)
+        result = param.container_parser.parse(carry)
         carry.clear()
 
         return result
@@ -130,12 +128,10 @@ class SignatureParser(signature_parser_trait.SignatureParser):
         param: param_info.ParamInfo[typing.Any],
         carry: typing.List[typing.Any],
     ) -> typing.Collection[typing.Any]:
-        assert param.container
-
         for arg in arg_iter:
             carry.append(param.parser.parse(arg))
 
-        return param.container.__call__(carry)
+        return param.container_parser.parse(carry)
 
     def _try_default_pos(
         self,
@@ -143,12 +139,14 @@ class SignatureParser(signature_parser_trait.SignatureParser):
     ) -> typing.Any:
         if not param.default:
             raise RuntimeError(f"Required parameter {param.name} was not supplied a value.")
-        if param.container:
-            return param.container.__call__([param.default])
 
-        return param.default
+        return param.container_parser.parse([param.default])
 
-    def _parse_pos(self, args: typing.Sequence[str]) -> typing.Sequence[typing.Any]:
+    def _parse_pos(  # noqa: C901
+        self,
+        args: typing.Sequence[str],
+        results_store: typing.List[typing.Any],
+    ) -> typing.Sequence[typing.Any]:
         n_pos = len(self.pos_params)
         pos_iter = enumerate(self.pos_params, 1)
         arg_iter = iter(args)
@@ -156,79 +154,78 @@ class SignatureParser(signature_parser_trait.SignatureParser):
         # Temporary storage for parsed args, also used to carry args between iterations.
         carry: typing.List[typing.Any] = []
 
-        # Storage for final results.
-        arg_results: typing.List[typing.Any] = []
         for next_idx, param in pos_iter:
 
             if param.greedy:
                 if next_idx >= n_pos:
                     # No remaining params, parse all remaining args
-                    arg_results.append(self._consume_remaining_pos(arg_iter, param, carry))
+                    results_store.append(self._consume_remaining_pos(arg_iter, param, carry))
                     break
 
                 # Keep parsing args until we fail, only then continue to next param.
-                arg_results.append(
+                results_store.append(
                     self._consume_greedy_pos(arg_iter, param, self.pos_params[next_idx], carry)
                 )
 
-            elif param.container:
+            elif param.has_container:
                 if next_idx >= n_pos:
                     # No remaining params, parse all remaining args
-                    arg_results.append(self._consume_remaining_pos(arg_iter, param, carry))
+                    results_store.append(self._consume_remaining_pos(arg_iter, param, carry))
                     break
 
                 # Non-greedily parse args, stop as soon as the next parser succeeds.
-                arg_results.append(
+                results_store.append(
                     self._consume_nongreedy_pos(arg_iter, param, self.pos_params[next_idx], carry)
                 )
 
             elif carry:
                 # If we already have a result, and this param does not return a
                 # collection, that result should be assigned to this param.
-                arg_results.append(carry[0])
+                results_store.append(carry[0])
                 carry.clear()
 
             else:
                 # If we don't have results yet, consume the next arg.
                 try:
-                    arg_results.append(param.parser.parse(next(arg_iter)))
+                    results_store.append(param.parser.parse(next(arg_iter)))
 
                 except StopIteration:
                     # If there is no next arg, try to get the default instead.
-                    arg_results.append(self._try_default_pos(param))
+                    results_store.append(self._try_default_pos(param))
                     break
 
         for _, param in pos_iter:
             # Try to supply any remaining parameters with their defaults, if any.
             # Error if any of these params does not have a default.
-            arg_results.append(self._try_default_pos(param))
+            results_store.append(self._try_default_pos(param))
 
         remaining = "', '".join(arg for arg in arg_iter)
         if remaining:
             # Any remaining args should raise.
             raise RuntimeError(f"Got too many positional arguments: '{remaining}' remain unused.")
 
-        return arg_results
+        return results_store
 
     def _parse_kw(
-        self, kwargs: typing.Mapping[str, typing.Sequence[str]]
+        self,
+        kwargs: typing.Mapping[str, typing.Sequence[str]],
+        results_store: typing.Dict[str, typing.Any],
     ) -> typing.Mapping[str, typing.Any]:
         if not set(self.kw_params).issuperset(kwargs):
             remainder = "', '".join(set(self.kw_params).symmetric_difference(kwargs))
             raise RuntimeError(f"Got one or more unexpected keyword arguments: '{remainder}'")
 
         carry: typing.Sequence[typing.Any] = []
-        kwarg_results: typing.Mapping[str, typing.Any] = {}
         for name, param in self.kw_params.items():
             if param.type is bool:
-                kwarg_results[name] = param.short in kwargs or param.name in kwargs
+                results_store[name] = param.short in kwargs or param.name in kwargs
                 continue
 
             for arg in kwargs[name]:
                 carry.append(param.parser.parse(arg))
 
-            if param.container:
-                kwarg_results[name] = param.container.__call__(carry)
+            if param.has_container:
+                results_store[name] = param.container_parser.parse(carry)
                 carry.clear()
 
             elif len(carry) > 1:
@@ -238,14 +235,40 @@ class SignatureParser(signature_parser_trait.SignatureParser):
                 )
 
             else:
-                kwarg_results[name] = carry[0]
+                results_store[name] = carry[0]
                 carry.clear()
 
-        return kwarg_results
+        return results_store
+
+    def _parse(
+        self,
+        args: typing.Sequence[str],
+        kwargs: typing.Mapping[str, typing.Sequence[str]],
+    ):
+        pos_results: typing.List[typing.Any] = []
+        try:
+            parsed_args = self._parse_pos(args, pos_results)
+
+        except errors.ConversionError as exc:
+            # Add whatever we did manage to convert to the exception for debugging
+            exc.converted = pos_results
+            raise exc
+
+        kw_results: typing.Dict[str, typing.Any] = {}
+        try:
+            parsed_kwargs = self._parse_kw(kwargs, kw_results)
+        
+        except errors.ConversionError as exc:
+            exc.converted = kw_results
+            raise exc
+
+        return parsed_args, parsed_kwargs
+
+
 
     def parse(
         self,
         invocation: str,
     ) -> typing.Tuple[typing.Sequence[typing.Any], typing.Mapping[str, typing.Any]]:
         args, kwargs = parser.parse_content(invocation)
-        return (self._parse_pos(args), self._parse_kw(kwargs))
+        return self._parse(args, kwargs)

--- a/sail/internal/debug.py
+++ b/sail/internal/debug.py
@@ -1,0 +1,27 @@
+import logging
+
+from velum import models
+from velum.events import message_events
+
+from sail.impl import command_manager
+
+_LOGGER = logging.getLogger("velum.debug")
+
+
+async def test_invoke(manager: command_manager.CommandManager, invocation: str) -> None:
+    debug_message = models.Message(author="DEBUG", content=invocation)
+    debug_event = message_events.MessageCreateEvent(message=debug_message)
+
+    try:
+        await manager.try_invoke(debug_event)
+
+    except Exception as exc:
+        exc_info = type(exc), exc, exc.__traceback__  #.tb_next if exc.__traceback__ else None
+
+        _LOGGER.error(
+            "Test invocation failed.",
+            exc_info=exc_info,
+        )
+
+    else:
+        _LOGGER.debug("Test invocation successful.")

--- a/sail/internal/debug.py
+++ b/sail/internal/debug.py
@@ -1,4 +1,5 @@
 import logging
+import time
 
 from velum import models
 from velum.events import message_events
@@ -12,6 +13,8 @@ async def test_invoke(manager: command_manager.CommandManager, invocation: str) 
     debug_message = models.Message(author="DEBUG", content=invocation)
     debug_event = message_events.MessageCreateEvent(message=debug_message)
 
+    start = time.monotonic()
+
     try:
         await manager.try_invoke(debug_event)
 
@@ -24,4 +27,5 @@ async def test_invoke(manager: command_manager.CommandManager, invocation: str) 
         )
 
     else:
-        _LOGGER.debug("Test invocation successful.")
+        duration = (time.monotonic() - start) * 1000
+        _LOGGER.debug(f"Test invocation successful in {duration:.3f} [ms].")

--- a/sail/internal/parser.py
+++ b/sail/internal/parser.py
@@ -25,7 +25,7 @@ _QUOTES: typing.Mapping[str, str] = {
 }
 
 
-def parse_content(
+def parse_content(  # noqa: C901
     content: str,
 ) -> typing.Tuple[typing.Sequence[str], typing.Mapping[str, typing.Sequence[str]]]:
     content_iter = iter(content)

--- a/sail/internal/typing_utils.py
+++ b/sail/internal/typing_utils.py
@@ -3,6 +3,7 @@ import typing
 
 __all__: typing.Sequence[str] = (
     "Greedy",
+    "JoinedStr",
     "SpecialType",
     "unpack_typehint",
 )
@@ -10,11 +11,12 @@ __all__: typing.Sequence[str] = (
 
 class SpecialType(enum.Enum):
     GREEDY = enum.auto()
-    # Perhaps more later?
+    JOINEDSTR = enum.auto()
 
 
 CollectionT = typing.TypeVar("CollectionT", bound=typing.Collection[typing.Any])
 Greedy = typing.Annotated[CollectionT, SpecialType.GREEDY]
+JoinedStr = typing.Annotated[str, SpecialType.JOINEDSTR]
 
 
 def unpack_typehint(

--- a/sail/traits/argument_parser_trait.py
+++ b/sail/traits/argument_parser_trait.py
@@ -1,12 +1,12 @@
-import inspect
 import typing
+
+from sail.internal import empty
 
 __all__: typing.Sequence[str] = ("ArgumentParser",)
 
 
 T = typing.TypeVar("T")
-
-empty = inspect.Parameter.empty
+ContainerT = typing.TypeVar("ContainerT", bound=typing.Container[typing.Any])
 
 
 class ArgumentParser(typing.Protocol[T]):
@@ -16,5 +16,20 @@ class ArgumentParser(typing.Protocol[T]):
     def __type__(self) -> typing.Type[T]:
         ...
 
-    def parse(self, argument: str, default: T | typing.Type[empty] = empty) -> T:
+    def parse(self, argument: str, default: T | empty.Empty = empty.EMPTY) -> T:
+        ...
+
+
+class ContainerParser(typing.Protocol[ContainerT]):
+    __slots__: typing.Sequence[str] = ()
+
+    @property
+    def __type__(self) -> typing.Type[ContainerT]:
+        ...
+
+    def parse(
+        self,
+        argument: typing.Iterable[str],
+        default: ContainerT | empty.Empty = empty.EMPTY
+    ) -> ContainerT:
         ...

--- a/sail/traits/argument_parser_trait.py
+++ b/sail/traits/argument_parser_trait.py
@@ -29,7 +29,7 @@ class ContainerParser(typing.Protocol[ContainerT]):
 
     def parse(
         self,
-        argument: typing.Iterable[str],
+        argument: typing.Sequence[object],
         default: ContainerT | empty.Empty = empty.EMPTY
     ) -> ContainerT:
         ...


### PR DESCRIPTION
Currently, container parsing is done entirely statically by the lib, and is not customisable. This is done by simply constructing the container type with the argument list, e.g. a parameter annotated as `Tuple[str]` could do something like `tuple(["a", "b"])` under the hood.

With this PR, the control flow for argument parsers is extended to work for container types. Much like the pre-existing `StringParser` and co., this PR implements a `SequenceParser`, `SetParser`, and `UnpackParser` to replace the existing functionality, and provides the user the opportunity to create and provide their own parsers through the use of a new `@param()` decorator.

A new example file for these new container parsers and the pre-existing argument parsers was added for clarity.

This is technically a breaking change as this changes the `ParamInfo` api, but since this wasn't really exposed anyways, this shouldn't prove too much of an issue.

Also something something scope screep debug function, oops.